### PR TITLE
feat(did): update publicKey type and return null for nonexistent did

### DIFF
--- a/lib/did/methods/eth-resolver.js
+++ b/lib/did/methods/eth-resolver.js
@@ -15,7 +15,7 @@ const generateDocument = (did, address) => ({
 	publicKey: [
 		{
 			id: `${did}#keys-1`,
-			type: 'Secp256k1VerificationKey2018',
+			type: 'EcdsaSecp256k1VerificationKey2019',
 			controller: did,
 			ethereumAddress: address
 		}

--- a/lib/did/methods/selfkey-resolver.js
+++ b/lib/did/methods/selfkey-resolver.js
@@ -19,7 +19,7 @@ const generateDocument = (did, address) => ({
 	publicKey: [
 		{
 			id: `${did}#keys-1`,
-			type: 'Secp256k1VerificationKey2018',
+			type: 'EcdsaSecp256k1VerificationKey2019',
 			controller: did,
 			ethereumAddress: address
 		}
@@ -35,18 +35,9 @@ const resolver = () => ({
 			throw new Error('Not a valid selfkey DID');
 		}
 
-		const chain = !params
-			? 'mainnet'
-			: !params['selfkey:chain']
-			? 'mainnet'
-			: params['selfkey:chain'];
+		const chain = !params || !params['selfkey:chain'] ? 'mainnet' : params['selfkey:chain'];
 		const address = await (0, _selfkeySimpleResolver.getControllerAddress)(idString, chain);
-
-		if (address === '0x0000000000000000000000000000000000000000') {
-			throw new Error('Controller Address Not Found');
-		}
-
-		return generateDocument(did, address);
+		return !address ? null : generateDocument(did, address);
 	}
 });
 

--- a/lib/did/methods/selfkey-simple-resolver.js
+++ b/lib/did/methods/selfkey-simple-resolver.js
@@ -30,7 +30,8 @@ const getControllerAddress = async (idString, chain) => {
 	if (!contractConfig) throw new Error('Not a valid Chain');
 	const web3 = new _web.default(contractConfig.url);
 	const ledger = new web3.eth.Contract(_DIDLedger.abi, contractConfig.address);
-	return ledger.methods.getController(idString).call();
+	const address = ledger.methods.getController(idString).call();
+	return address !== '0x0000000000000000000000000000000000000000' ? address : null;
 };
 
 exports.getControllerAddress = getControllerAddress;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfkey/node-lib",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "SelfKey Javascript Library",
   "keywords": [
     "selfkey",
@@ -38,7 +38,7 @@
     "@babel/cli": "7.4.3",
     "@babel/core": "7.4.3",
     "@babel/preset-env": "7.4.3",
-    "@commitlint/cli": "7.2.1",
+    "@commitlint/cli": "8.1.0",
     "@commitlint/config-conventional": "7.1.2",
     "babel-eslint": "10.0.1",
     "babel-jest": "24.7.1",

--- a/src/did/methods/eth-resolver.js
+++ b/src/did/methods/eth-resolver.js
@@ -7,7 +7,7 @@ const generateDocument = (did, address) => ({
 	publicKey: [
 		{
 			id: `${did}#keys-1`,
-			type: 'Secp256k1VerificationKey2018',
+			type: 'EcdsaSecp256k1VerificationKey2019',
 			controller: did,
 			ethereumAddress: address
 		}

--- a/src/did/methods/eth-resolver.spec.js
+++ b/src/did/methods/eth-resolver.spec.js
@@ -35,7 +35,7 @@ describe('resolve', () => {
 			publicKey: [
 				{
 					id: 'did:eth:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#keys-1',
-					type: 'Secp256k1VerificationKey2018',
+					type: 'EcdsaSecp256k1VerificationKey2019',
 					controller: 'did:eth:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74',
 					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
 				}

--- a/src/did/methods/selfkey-resolver.js
+++ b/src/did/methods/selfkey-resolver.js
@@ -11,7 +11,7 @@ const generateDocument = (did, address) => ({
 	publicKey: [
 		{
 			id: `${did}#keys-1`,
-			type: 'Secp256k1VerificationKey2018',
+			type: 'EcdsaSecp256k1VerificationKey2019',
 			controller: did,
 			ethereumAddress: address
 		}
@@ -25,15 +25,8 @@ export const resolver = () => ({
 		if (method !== 'selfkey' || !isValidIdentifier(idString)) {
 			throw new Error('Not a valid selfkey DID');
 		}
-		const chain = !params
-			? 'mainnet'
-			: !params['selfkey:chain']
-			? 'mainnet'
-			: params['selfkey:chain'];
+		const chain = !params || !params['selfkey:chain'] ? 'mainnet' : params['selfkey:chain'];
 		const address = await getControllerAddress(idString, chain);
-		if (address === '0x0000000000000000000000000000000000000000') {
-			throw new Error('Controller Address Not Found');
-		}
-		return generateDocument(did, address);
+		return !address ? null : generateDocument(did, address);
 	}
 });

--- a/src/did/methods/selfkey-resolver.js
+++ b/src/did/methods/selfkey-resolver.js
@@ -6,17 +6,21 @@ const isValidIdentifier = idString => {
 };
 
 const generateDocument = (did, address) => ({
-	'@context': 'https://www.w3.org/2019/did/v1',
-	id: did,
-	publicKey: [
-		{
-			id: `${did}#keys-1`,
-			type: 'EcdsaSecp256k1VerificationKey2019',
-			controller: did,
-			ethereumAddress: address
-		}
-	],
-	authentication: [`${did}#keys-1`]
+	didDocument: {
+		'@context': 'https://www.w3.org/2019/did/v1',
+		id: did,
+		publicKey: [
+			{
+				id: `${did}#keys-1`,
+				type: 'EcdsaSecp256k1VerificationKey2019',
+				controller: did,
+				ethereumAddress: address
+			}
+		],
+		authentication: [`${did}#keys-1`]
+	},
+	resolverMetadata: {},
+	methodMetadata: {}
 });
 
 export const resolver = () => ({

--- a/src/did/methods/selfkey-resolver.spec.js
+++ b/src/did/methods/selfkey-resolver.spec.js
@@ -31,6 +31,13 @@ describe('resolve', () => {
 		}
 	});
 
+	it('DID does not exist', async () => {
+		getControllerAddress.mockResolvedValueOnce(null);
+		const did =
+			'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120';
+		expect(await resolve(did)).toBeNull();
+	});
+
 	it('DID resolved with no param', async () => {
 		const did =
 			'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120';
@@ -41,7 +48,7 @@ describe('resolve', () => {
 				{
 					id:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120#keys-1',
-					type: 'Secp256k1VerificationKey2018',
+					type: 'EcdsaSecp256k1VerificationKey2019',
 					controller:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
 					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
@@ -68,7 +75,7 @@ describe('resolve', () => {
 				{
 					id:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten#keys-1',
-					type: 'Secp256k1VerificationKey2018',
+					type: 'EcdsaSecp256k1VerificationKey2019',
 					controller:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten',
 					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
@@ -95,7 +102,7 @@ describe('resolve', () => {
 				{
 					id:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten#keys-1',
-					type: 'Secp256k1VerificationKey2018',
+					type: 'EcdsaSecp256k1VerificationKey2019',
 					controller:
 						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten',
 					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'

--- a/src/did/methods/selfkey-resolver.spec.js
+++ b/src/did/methods/selfkey-resolver.spec.js
@@ -42,21 +42,25 @@ describe('resolve', () => {
 		const did =
 			'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120';
 		expect(await resolve(did)).toEqual({
-			'@context': 'https://www.w3.org/2019/did/v1',
-			id: 'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
-			publicKey: [
-				{
-					id:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120#keys-1',
-					type: 'EcdsaSecp256k1VerificationKey2019',
-					controller:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
-					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
-				}
-			],
-			authentication: [
-				'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120#keys-1'
-			]
+			didDocument: {
+				'@context': 'https://www.w3.org/2019/did/v1',
+				id: 'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
+				publicKey: [
+					{
+						id:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120#keys-1',
+						type: 'EcdsaSecp256k1VerificationKey2019',
+						controller:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
+						ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
+					}
+				],
+				authentication: [
+					'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120#keys-1'
+				]
+			},
+			resolverMetadata: {},
+			methodMetadata: {}
 		});
 		expect(getControllerAddress).toHaveBeenCalledWith(
 			'0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
@@ -68,22 +72,26 @@ describe('resolve', () => {
 		const did =
 			'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten';
 		expect(await resolve(did)).toEqual({
-			'@context': 'https://www.w3.org/2019/did/v1',
-			id:
-				'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten',
-			publicKey: [
-				{
-					id:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten#keys-1',
-					type: 'EcdsaSecp256k1VerificationKey2019',
-					controller:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten',
-					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
-				}
-			],
-			authentication: [
-				'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten#keys-1'
-			]
+			didDocument: {
+				'@context': 'https://www.w3.org/2019/did/v1',
+				id:
+					'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten',
+				publicKey: [
+					{
+						id:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten#keys-1',
+						type: 'EcdsaSecp256k1VerificationKey2019',
+						controller:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten',
+						ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
+					}
+				],
+				authentication: [
+					'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:chain=ropsten#keys-1'
+				]
+			},
+			resolverMetadata: {},
+			methodMetadata: {}
 		});
 		expect(getControllerAddress).toHaveBeenCalledWith(
 			'0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',
@@ -95,22 +103,26 @@ describe('resolve', () => {
 		const did =
 			'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten';
 		expect(await resolve(did)).toEqual({
-			'@context': 'https://www.w3.org/2019/did/v1',
-			id:
-				'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten',
-			publicKey: [
-				{
-					id:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten#keys-1',
-					type: 'EcdsaSecp256k1VerificationKey2019',
-					controller:
-						'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten',
-					ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
-				}
-			],
-			authentication: [
-				'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten#keys-1'
-			]
+			didDocument: {
+				'@context': 'https://www.w3.org/2019/did/v1',
+				id:
+					'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten',
+				publicKey: [
+					{
+						id:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten#keys-1',
+						type: 'EcdsaSecp256k1VerificationKey2019',
+						controller:
+							'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten',
+						ethereumAddress: '0xf3beac30c498d9e26865f34fcaa57dbb935b0d74'
+					}
+				],
+				authentication: [
+					'did:selfkey:0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120;selfkey:network=ropsten#keys-1'
+				]
+			},
+			resolverMetadata: {},
+			methodMetadata: {}
 		});
 		expect(getControllerAddress).toHaveBeenCalledWith(
 			'0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120',

--- a/src/did/methods/selfkey-simple-resolver.js
+++ b/src/did/methods/selfkey-simple-resolver.js
@@ -17,5 +17,6 @@ export const getControllerAddress = async (idString, chain) => {
 	if (!contractConfig) throw new Error('Not a valid Chain');
 	const web3 = new Web3(contractConfig.url);
 	const ledger = new web3.eth.Contract(ledgerABI, contractConfig.address);
-	return ledger.methods.getController(idString).call();
+	const address = ledger.methods.getController(idString).call();
+	return address !== '0x0000000000000000000000000000000000000000' ? address : null;
 };

--- a/src/did/methods/selfkey-simple-resolver.spec.js
+++ b/src/did/methods/selfkey-simple-resolver.spec.js
@@ -28,6 +28,17 @@ describe('Selfkey Simple Resolver', () => {
 		mockGetControllerCall.mockClear();
 	});
 
+	it('Get null address', async () => {
+		const idString = '0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120';
+
+		mockGetControllerCall.mockReturnValue('0x0000000000000000000000000000000000000000');
+		const actualAddress = await getControllerAddress(idString, 'mainnet');
+		expect(Web3).toHaveBeenCalledWith(
+			'wss://mainnet.infura.io/ws/v3/2e5fb5cf42714929a7f61a1617ef1ffd'
+		);
+		expect(actualAddress).toBeNull();
+	});
+
 	it('Get Controller Address from Main', async () => {
 		const address = '0x27462DF3542882455E3bD6a23496a06E5E686162';
 		const idString = '0x11c47898a9d3498986129cdb0b8ac3ed468f5e400cb0076d40f355ad1ad2a120';

--- a/src/did/resolver.spec.js
+++ b/src/did/resolver.spec.js
@@ -23,8 +23,10 @@ describe('Resolver', () => {
 		registerMethodResolver('mock', {
 			resolve: async () =>
 				Promise.resolve({
-					'@context': 'https://www.w3.org/2019/did/v1',
-					id: 'did:mock:123456789abcdefghi'
+					didDocument: {
+						'@context': 'https://www.w3.org/2019/did/v1',
+						id: 'did:mock:123456789abcdefghi'
+					}
 				})
 		});
 	});
@@ -47,8 +49,10 @@ describe('Resolver', () => {
 
 	it('DID resolved', async () => {
 		expect(await resolve('did:mock:123456789abcdefghi')).toEqual({
-			'@context': 'https://www.w3.org/2019/did/v1',
-			id: 'did:mock:123456789abcdefghi'
+			didDocument: {
+				'@context': 'https://www.w3.org/2019/did/v1',
+				id: 'did:mock:123456789abcdefghi'
+			}
 		});
 	});
 });


### PR DESCRIPTION
Spec related updates:
- Update publicKey entry type property in generated DID Documents
- Return null instead of throwing error for nonexistent DID

Additional:
- Fix vulnerable dependencies
